### PR TITLE
link to pekko management docs

### DIFF
--- a/pekko-sample-cqrs-java/README.md
+++ b/pekko-sample-cqrs-java/README.md
@@ -1,3 +1,5 @@
 # Apache Pekko CQRS - Java Sample
 
 This example has been replaced by the [tutorial in the Akka Platform Guide](https://developer.lightbend.com/docs/akka-platform-guide/microservices-tutorial/index.html).
+
+We hope to migrate to create a Pekko equivalent of the Akka Platform Guide in time. 

--- a/pekko-sample-cqrs-scala/README.md
+++ b/pekko-sample-cqrs-scala/README.md
@@ -1,3 +1,5 @@
 # Apache Pekko CQRS - Scala Sample
 
 This example has been replaced by the [tutorial in the Akka Platform Guide](https://developer.lightbend.com/docs/akka-platform-guide/microservices-tutorial/index.html).
+
+We hope to migrate to create a Pekko equivalent of the Akka Platform Guide in time. 

--- a/pekko-sample-persistence-dc-java/src/main/resources/application.conf
+++ b/pekko-sample-persistence-dc-java/src/main/resources/application.conf
@@ -52,7 +52,7 @@ pekko.persistence.cassandra {
 datastax-java-driver.advanced.reconnect-on-init = true
 
 
-# Apache Pekko Management config: https://developer.lightbend.com/docs/akka-management/current/index.html
+# Apache Pekko Management config: https://pekko.apache.org/docs/pekko-management/current/
 pekko.management {
   http.hostname = "127.0.0.1"
   http.port = 19999

--- a/pekko-sample-persistence-dc-scala/src/main/resources/application.conf
+++ b/pekko-sample-persistence-dc-scala/src/main/resources/application.conf
@@ -52,7 +52,7 @@ pekko.persistence.cassandra {
 datastax-java-driver.advanced.reconnect-on-init = true
 
 
-# Apache Pekko Management config: https://developer.lightbend.com/docs/akka-management/current/index.html
+# Apache Pekko Management config: https://pekko.apache.org/docs/pekko-management/current/
 pekko.management {
   http.hostname = "127.0.0.1"
   http.port = 19999


### PR DESCRIPTION
* instead of linking to akka mgmt docs
* also highlight that the links to Akka Platform Guide are temporary