### PR TITLE
chore: update pekko-management-port

### DIFF
--- a/pekko-sample-cluster-kubernetes-java/README.md
+++ b/pekko-sample-cluster-kubernetes-java/README.md
@@ -52,7 +52,7 @@ for 'hello world':
 
 You can inspect the Apache Pekko Cluster membership status with the [Cluster HTTP Management](https://pekko.apache.org/docs/pekko-management/current/cluster-http-management.html).
 
-    curl http://127.0.0.1:8558/cluster/members/
+    curl http://127.0.0.1:7626/cluster/members/
 
 To check what you have done in Kubernetes so far, you can do:
 

--- a/pekko-sample-cluster-kubernetes-java/kubernetes/pekko-cluster.yml
+++ b/pekko-sample-cluster-kubernetes-java/kubernetes/pekko-cluster.yml
@@ -42,7 +42,7 @@ spec:
               protocol: TCP
             # pekko-management and bootstrap
             - name: management
-              containerPort: 8558
+              containerPort: 7626
               protocol: TCP
             - name: http
               containerPort: 8080

--- a/pekko-sample-cluster-kubernetes-java/pom.xml
+++ b/pekko-sample-cluster-kubernetes-java/pom.xml
@@ -100,7 +100,7 @@
                 <from>adoptopenjdk:11-jre-hotspot</from>
                 <ports>
                   <port>8080</port>
-                  <port>8558</port>
+                  <port>7626</port>
                 </ports>
                 <entryPoint>
                   java $JAVA_OPTS -cp '/maven/*' org.apache.pekko.cluster.bootstrap.demo.DemoApp

--- a/pekko-sample-cluster-kubernetes-scala/README.md
+++ b/pekko-sample-cluster-kubernetes-scala/README.md
@@ -53,7 +53,7 @@ for 'hello world':
 
 You can inspect the Apache Pekko Cluster membership status with the [Cluster HTTP Management](https://pekko.apache.org/docs/pekko-management/current/cluster-http-management.html).
 
-    curl http://127.0.0.1:8558/cluster/members/
+    curl http://127.0.0.1:7626/cluster/members/
 
 To check what you have done in Kubernetes so far, you can do:
 

--- a/pekko-sample-cluster-kubernetes-scala/build.sbt
+++ b/pekko-sample-cluster-kubernetes-scala/build.sbt
@@ -20,7 +20,7 @@ mainClass in (Compile, run) := Some("pekko.sample.cluster.kubernetes.DemoApp")
 
 enablePlugins(JavaServerAppPackaging, DockerPlugin)
 
-dockerExposedPorts := Seq(8080, 8558, 17355)
+dockerExposedPorts := Seq(8080, 7626, 17355)
 dockerUpdateLatest := true
 dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")

--- a/pekko-sample-cluster-kubernetes-scala/kubernetes/pekko-cluster.yml
+++ b/pekko-sample-cluster-kubernetes-scala/kubernetes/pekko-cluster.yml
@@ -38,7 +38,7 @@ spec:
         ports:
         # pekko-management and bootstrap
         - name: management
-          containerPort: 8558
+          containerPort: 7626
           protocol: TCP
         - name: http
           containerPort: 8080

--- a/pekko-sample-kafka-to-sharding-scala/processor/src/main/resources/application.conf
+++ b/pekko-sample-kafka-to-sharding-scala/processor/src/main/resources/application.conf
@@ -40,6 +40,6 @@ pekko {
 pekko.management {
   http {
     hostname = "127.0.0.1"
-    port = 8558
+    port = 7626
   }
 }


### PR DESCRIPTION
## Motivation

Update the port because we have a special meaning of port occupation.

https://github.com/apache/pekko-management/blob/1b7a52ba277daec3130baee4bf29a2f0f55a51bb/management/src/main/resources/reference.conf#L19