### PR TITLE
use pekko 1.1

### DIFF
--- a/pekko-sample-cluster-client-grpc-java/pom.xml
+++ b/pekko-sample-cluster-client-grpc-java/pom.xml
@@ -10,8 +10,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>1.1.0</pekko.version>
-    <pekko.grpc.version>1.1.0-M1</pekko.grpc.version>
+    <pekko.version>1.1.2</pekko.version>
+    <pekko.grpc.version>1.1.0</pekko.grpc.version>
   </properties>
 
   <dependencies>

--- a/pekko-sample-cluster-client-grpc-java/pom.xml
+++ b/pekko-sample-cluster-client-grpc-java/pom.xml
@@ -10,8 +10,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>1.0.3</pekko.version>
-    <pekko.grpc.version>1.0.2</pekko.grpc.version>
+    <pekko.version>1.1.0</pekko.version>
+    <pekko.grpc.version>1.1.0-M1</pekko.grpc.version>
   </properties>
 
   <dependencies>

--- a/pekko-sample-cluster-client-grpc-scala/build.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 
 lazy val `pekko-sample-cluster-client-grpc-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-client-grpc-scala/build.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.0.3"
+val pekkoVersion = "1.1.0"
 
 lazy val `pekko-sample-cluster-client-grpc-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-client-grpc-scala/project/plugins.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "0.1.8")
 addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "0.6.0")

--- a/pekko-sample-cluster-client-grpc-scala/project/plugins.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
 addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "0.1.8")
 addSbtPlugin("com.github.sbt" % "sbt-multi-jvm" % "0.6.0")

--- a/pekko-sample-cluster-docker-compose-java/build.sbt
+++ b/pekko-sample-cluster-docker-compose-java/build.sbt
@@ -10,8 +10,8 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-Xlint")
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 /* dependencies */
 libraryDependencies ++= Seq(

--- a/pekko-sample-cluster-docker-compose-java/build.sbt
+++ b/pekko-sample-cluster-docker-compose-java/build.sbt
@@ -10,7 +10,7 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-Xlint")
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 /* dependencies */

--- a/pekko-sample-cluster-docker-compose-scala/build.sbt
+++ b/pekko-sample-cluster-docker-compose-scala/build.sbt
@@ -11,7 +11,7 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-Xlint")
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 /* dependencies */

--- a/pekko-sample-cluster-docker-compose-scala/build.sbt
+++ b/pekko-sample-cluster-docker-compose-scala/build.sbt
@@ -11,8 +11,8 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-Xlint")
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 /* dependencies */
 libraryDependencies ++= Seq(

--- a/pekko-sample-cluster-java/build.sbt
+++ b/pekko-sample-cluster-java/build.sbt
@@ -1,8 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 lazy val `pekko-sample-cluster-java` = project
   .in(file("."))

--- a/pekko-sample-cluster-java/build.sbt
+++ b/pekko-sample-cluster-java/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 lazy val `pekko-sample-cluster-java` = project

--- a/pekko-sample-cluster-java/pom.xml
+++ b/pekko-sample-cluster-java/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>1.0.3</pekko.version>
+    <pekko.version>1.1.0</pekko.version>
   </properties>
 
   <dependencies>
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.pekko</groupId>

--- a/pekko-sample-cluster-java/pom.xml
+++ b/pekko-sample-cluster-java/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>1.1.0</pekko.version>
+    <pekko.version>1.1.2</pekko.version>
   </properties>
 
   <dependencies>

--- a/pekko-sample-cluster-kubernetes-java/pom.xml
+++ b/pekko-sample-cluster-kubernetes-java/pom.xml
@@ -20,7 +20,7 @@
     <encoding>UTF-8</encoding>
     <pekko.version>1.1.2</pekko.version>
     <pekko-http.version>1.1.0</pekko-http.version>
-    <pekko-management.version>1.1.0-M1</pekko-management.version>
+    <pekko-management.version>1.1.0</pekko-management.version>
     <scala.binary.version>2.13</scala.binary.version>
     <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
   </properties>

--- a/pekko-sample-cluster-kubernetes-java/pom.xml
+++ b/pekko-sample-cluster-kubernetes-java/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <pekko.version>1.1.0</pekko.version>
+    <pekko.version>1.1.2</pekko.version>
     <pekko-http.version>1.1.0</pekko-http.version>
     <pekko-management.version>1.1.0-M1</pekko-management.version>
     <scala.binary.version>2.13</scala.binary.version>

--- a/pekko-sample-cluster-kubernetes-java/pom.xml
+++ b/pekko-sample-cluster-kubernetes-java/pom.xml
@@ -18,9 +18,9 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <pekko.version>1.0.3</pekko.version>
-    <pekko-http.version>1.0.1</pekko-http.version>
-    <pekko-management.version>1.0.0</pekko-management.version>
+    <pekko.version>1.1.0</pekko.version>
+    <pekko-http.version>1.1.0</pekko-http.version>
+    <pekko-management.version>1.1.0-M1</pekko-management.version>
     <scala.binary.version>2.13</scala.binary.version>
     <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
   </properties>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.pekko</groupId>

--- a/pekko-sample-cluster-kubernetes-scala/build.sbt
+++ b/pekko-sample-cluster-kubernetes-scala/build.sbt
@@ -5,7 +5,7 @@ name := "pekko-sample-cluster-kubernetes-scala"
 scalaVersion := "2.13.15"
 val pekkoHttpVersion = "1.1.0"
 val pekkoVersion = "1.1.2"
-val pekkoManagementVersion = "1.1.0-M1"
+val pekkoManagementVersion = "1.1.0"
 val logbackVersion = "1.3.14"
 
 // make version compatible with docker for publishing

--- a/pekko-sample-cluster-kubernetes-scala/build.sbt
+++ b/pekko-sample-cluster-kubernetes-scala/build.sbt
@@ -3,10 +3,10 @@ ThisBuild / organization := "org.apache.pekko"
 name := "pekko-sample-cluster-kubernetes-scala"
 
 scalaVersion := "2.13.15"
-val pekkoHttpVersion = "1.0.1"
-val pekkoVersion = "1.0.3"
-val pekkoManagementVersion = "1.0.0"
-val logbackVersion = "1.2.13"
+val pekkoHttpVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
+val pekkoManagementVersion = "1.1.0-M1"
+val logbackVersion = "1.3.14"
 
 // make version compatible with docker for publishing
 ThisBuild / dynverSeparator := "-"

--- a/pekko-sample-cluster-scala/build.sbt
+++ b/pekko-sample-cluster-scala/build.sbt
@@ -1,8 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 lazy val `pekko-sample-cluster-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-scala/build.sbt
+++ b/pekko-sample-cluster-scala/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 lazy val `pekko-sample-cluster-scala` = project

--- a/pekko-sample-distributed-data-java/build.sbt
+++ b/pekko-sample-distributed-data-java/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 val `pekko-sample-distributed-data-java` = project

--- a/pekko-sample-distributed-data-java/build.sbt
+++ b/pekko-sample-distributed-data-java/build.sbt
@@ -1,8 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 val `pekko-sample-distributed-data-java` = project
   .in(file("."))

--- a/pekko-sample-distributed-data-scala/build.sbt
+++ b/pekko-sample-distributed-data-scala/build.sbt
@@ -1,8 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 val `pekko-sample-distributed-data-scala` = project
   .in(file("."))

--- a/pekko-sample-distributed-data-scala/build.sbt
+++ b/pekko-sample-distributed-data-scala/build.sbt
@@ -1,7 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 val `pekko-sample-distributed-data-scala` = project

--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 
 scalaVersion := "2.13.15"
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val cassandraPluginVersion = "1.1.0-M1"
 val logbackVersion = "1.3.14"
 

--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -4,9 +4,9 @@ version := "1.0"
 
 scalaVersion := "2.13.15"
 
-val pekkoVersion = "1.0.3"
-val cassandraPluginVersion = "1.0.0"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val cassandraPluginVersion = "1.1.0-M1"
+val logbackVersion = "1.3.14"
 
 Global / cancelable := false
 

--- a/pekko-sample-fsm-java/pom.xml
+++ b/pekko-sample-fsm-java/pom.xml
@@ -6,7 +6,7 @@
 
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <pekko.version>1.0.3</pekko.version>
+      <pekko.version>1.1.0</pekko.version>
   </properties>
 
   <groupId>org.apache.pekko</groupId>
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.14</version>
     </dependency>
   </dependencies>
 

--- a/pekko-sample-fsm-java/pom.xml
+++ b/pekko-sample-fsm-java/pom.xml
@@ -6,7 +6,7 @@
 
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <pekko.version>1.1.0</pekko.version>
+      <pekko.version>1.1.2</pekko.version>
   </properties>
 
   <groupId>org.apache.pekko</groupId>

--- a/pekko-sample-fsm-scala/build.sbt
+++ b/pekko-sample-fsm-scala/build.sbt
@@ -1,8 +1,8 @@
 organization := "org.apache.pekko"
 name := "pekko-sample-fsm-scala"
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 scalaVersion := "2.13.15"
 libraryDependencies ++= Seq(

--- a/pekko-sample-fsm-scala/build.sbt
+++ b/pekko-sample-fsm-scala/build.sbt
@@ -1,7 +1,7 @@
 organization := "org.apache.pekko"
 name := "pekko-sample-fsm-scala"
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 scalaVersion := "2.13.15"

--- a/pekko-sample-grpc-kubernetes-scala/build.sbt
+++ b/pekko-sample-grpc-kubernetes-scala/build.sbt
@@ -1,9 +1,9 @@
 name := "pekko-grpc-kubernetes"
 scalaVersion := "2.13.15"
 
-lazy val pekkoVersion = "1.0.3"
-lazy val discoveryVersion = "1.0.0"
-lazy val pekkoHttpVersion = "1.0.1"
+lazy val pekkoVersion = "1.1.1"
+lazy val discoveryVersion = "1.1.0-M1"
+lazy val pekkoHttpVersion = "1.1.0"
 
 lazy val root = (project in file("."))
   .aggregate(httpToGrpc, grpcService)
@@ -23,7 +23,7 @@ lazy val httpToGrpc = (project in file("http-to-grpc"))
       "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
       "org.apache.pekko" %% "pekko-discovery-kubernetes-api" % discoveryVersion,
-      "ch.qos.logback" % "logback-classic" % "1.2.13"),
+      "ch.qos.logback" % "logback-classic" % "1.3.14"),
     dockerExposedPorts := Seq(8080))
 
 // gRPC back end that echoes back messages
@@ -39,4 +39,4 @@ lazy val grpcService = (project in file("grpc-service"))
       "org.apache.pekko" %% "pekko-stream" % pekkoVersion,
       "org.apache.pekko" %% "pekko-discovery" % pekkoVersion,
       "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
-      "ch.qos.logback" % "logback-classic" % "1.2.13"))
+      "ch.qos.logback" % "logback-classic" % "1.3.14"))

--- a/pekko-sample-grpc-kubernetes-scala/build.sbt
+++ b/pekko-sample-grpc-kubernetes-scala/build.sbt
@@ -1,7 +1,7 @@
 name := "pekko-grpc-kubernetes"
 scalaVersion := "2.13.15"
 
-lazy val pekkoVersion = "1.1.1"
+lazy val pekkoVersion = "1.1.2"
 lazy val discoveryVersion = "1.1.0-M1"
 lazy val pekkoHttpVersion = "1.1.0"
 

--- a/pekko-sample-grpc-kubernetes-scala/build.sbt
+++ b/pekko-sample-grpc-kubernetes-scala/build.sbt
@@ -2,7 +2,7 @@ name := "pekko-grpc-kubernetes"
 scalaVersion := "2.13.15"
 
 lazy val pekkoVersion = "1.1.2"
-lazy val discoveryVersion = "1.1.0-M1"
+lazy val pekkoManagementVersion = "1.1.0"
 lazy val pekkoHttpVersion = "1.1.0"
 
 lazy val root = (project in file("."))
@@ -22,7 +22,7 @@ lazy val httpToGrpc = (project in file("http-to-grpc"))
       "org.apache.pekko" %% "pekko-http-core" % pekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
-      "org.apache.pekko" %% "pekko-discovery-kubernetes-api" % discoveryVersion,
+      "org.apache.pekko" %% "pekko-discovery-kubernetes-api" % pekkoManagementVersion,
       "ch.qos.logback" % "logback-classic" % "1.3.14"),
     dockerExposedPorts := Seq(8080))
 

--- a/pekko-sample-grpc-kubernetes-scala/project/plugins.sbt
+++ b/pekko-sample-grpc-kubernetes-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
 
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")

--- a/pekko-sample-grpc-kubernetes-scala/project/plugins.sbt
+++ b/pekko-sample-grpc-kubernetes-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
 
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")

--- a/pekko-sample-kafka-to-sharding-scala/build.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/build.sbt
@@ -2,7 +2,7 @@ val pekkoVersion = "1.1.2"
 val pekkoHttpVersion = "1.1.0"
 
 val pekkoConnectorsKafkaVersion = "1.1.0"
-val pekkoManagementVersion = "1.1.0-M1"
+val pekkoManagementVersion = "1.1.0"
 val EmbeddedKafkaVersion = "2.4.1.1"
 val logbackVersion = "1.3.14"
 val slf4jVersion = "2.0.16"

--- a/pekko-sample-kafka-to-sharding-scala/build.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/build.sbt
@@ -1,10 +1,10 @@
-val pekkoVersion = "1.0.3"
-val pekkoHttpVersion = "1.0.1"
+val pekkoVersion = "1.1.0"
+val pekkoHttpVersion = "1.1.0"
 
-val pekkoConnectorsKafkaVersion = "1.0.0"
-val pekkoManagementVersion = "1.0.0"
+val pekkoConnectorsKafkaVersion = "1.1.0-M1"
+val pekkoManagementVersion = "1.1.0-M1"
 val EmbeddedKafkaVersion = "2.4.1.1"
-val logbackVersion = "1.2.13"
+val logbackVersion = "1.3.14"
 val slf4jVersion = "1.7.32"
 
 ThisBuild / scalaVersion := "2.13.15"

--- a/pekko-sample-kafka-to-sharding-scala/build.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/build.sbt
@@ -5,7 +5,7 @@ val pekkoConnectorsKafkaVersion = "1.1.0"
 val pekkoManagementVersion = "1.1.0-M1"
 val EmbeddedKafkaVersion = "2.4.1.1"
 val logbackVersion = "1.3.14"
-val slf4jVersion = "1.7.32"
+val slf4jVersion = "2.0.16"
 
 ThisBuild / scalaVersion := "2.13.15"
 ThisBuild / organization := "org.apache.pekko"

--- a/pekko-sample-kafka-to-sharding-scala/build.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/build.sbt
@@ -1,7 +1,7 @@
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val pekkoHttpVersion = "1.1.0"
 
-val pekkoConnectorsKafkaVersion = "1.1.0-M1"
+val pekkoConnectorsKafkaVersion = "1.1.0"
 val pekkoManagementVersion = "1.1.0-M1"
 val EmbeddedKafkaVersion = "2.4.1.1"
 val logbackVersion = "1.3.14"

--- a/pekko-sample-kafka-to-sharding-scala/project/plugins.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "0.1.8") // ALPN agent
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")

--- a/pekko-sample-kafka-to-sharding-scala/project/plugins.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
 
 addSbtPlugin("com.github.sbt" % "sbt-javaagent" % "0.1.8") // ALPN agent
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.17"

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <pekko.version>1.1.2</pekko.version>
-    <pekko-persistence-cassandra.version>1.1.0</pekko-persistence-cassandra.version>
+    <pekko-persistence-cassandra.version>1.1.0-M1</pekko-persistence-cassandra.version>
     <pekko-http.version>1.1.0</pekko-http.version>
     <pekko-management.version>1.1.0</pekko-management.version>
   </properties>

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -19,9 +19,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <pekko.version>1.1.2</pekko.version>
-    <pekko-persistence-cassandra.version>1.1.0-M1</pekko-persistence-cassandra.version>
+    <pekko-persistence-cassandra.version>1.1.0</pekko-persistence-cassandra.version>
     <pekko-http.version>1.1.0</pekko-http.version>
-    <pekko-management.version>1.1.0-M1</pekko-management.version>
+    <pekko-management.version>1.1.0</pekko-management.version>
   </properties>
 
    <dependencies>

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -18,10 +18,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>1.0.3</pekko.version>
-    <pekko-persistence-cassandra.version>1.0.0</pekko-persistence-cassandra.version>
-    <pekko-http.version>1.0.1</pekko-http.version>
-    <pekko-management.version>1.0.0</pekko-management.version>
+    <pekko.version>1.1.0</pekko.version>
+    <pekko-persistence-cassandra.version>1.1.0-M1</pekko-persistence-cassandra.version>
+    <pekko-http.version>1.1.0</pekko-http.version>
+    <pekko-management.version>1.1.0-M1</pekko-management.version>
   </properties>
 
    <dependencies>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.14</version>
     </dependency>
      <dependency>
       <groupId>org.apache.pekko</groupId>

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>1.1.0</pekko.version>
+    <pekko.version>1.1.2</pekko.version>
     <pekko-persistence-cassandra.version>1.1.0-M1</pekko-persistence-cassandra.version>
     <pekko-http.version>1.1.0</pekko-http.version>
     <pekko-management.version>1.1.0-M1</pekko-management.version>

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -3,7 +3,7 @@ name := "pekko-sample-replicated-event-sourcing-scala"
 
 scalaVersion := "2.13.15"
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val cassandraPluginVersion = "1.1.0-M1"
 
 val pekkoHttpVersion = "1.1.0"

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -20,8 +20,8 @@ libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-management" % pekkoClusterManagementVersion,
   "org.apache.pekko" %% "pekko-management-cluster-http" % pekkoClusterManagementVersion,
   "org.apache.pekko" %% "pekko-persistence-cassandra" % cassandraPluginVersion,
-  "ch.qos.logback" % "logback-classic" % logbackVersion,
   "org.apache.pekko" %% "pekko-persistence-cassandra-launcher" % cassandraPluginVersion,
+  "ch.qos.logback" % "logback-classic" % logbackVersion,
   "org.apache.pekko" %% "pekko-persistence-testkit" % pekkoVersion % Test,
   "org.scalatest" %% "scalatest" % "3.2.19" % Test)
 

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -7,7 +7,7 @@ val pekkoVersion = "1.1.2"
 val cassandraPluginVersion = "1.1.0-M1"
 
 val pekkoHttpVersion = "1.1.0"
-val pekkoClusterManagementVersion = "1.1.0-M1"
+val pekkoClusterManagementVersion = "1.1.0"
 
 val logbackVersion = "1.3.14"
 

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -3,13 +3,13 @@ name := "pekko-sample-replicated-event-sourcing-scala"
 
 scalaVersion := "2.13.15"
 
-val pekkoVersion = "1.0.3"
-val cassandraPluginVersion = "1.0.0"
+val pekkoVersion = "1.1.0"
+val cassandraPluginVersion = "1.1.0-M1"
 
-val pekkoHttpVersion = "1.0.1"
-val pekkoClusterManagementVersion = "1.0.0"
+val pekkoHttpVersion = "1.1.0"
+val pekkoClusterManagementVersion = "1.1.0-M1"
 
-val logbackVersion = "1.2.13"
+val logbackVersion = "1.3.14"
 
 libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-cluster-sharding-typed" % pekkoVersion,

--- a/pekko-sample-persistence-java/pom.xml
+++ b/pekko-sample-persistence-java/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>1.0.3</pekko.version>
+        <pekko.version>1.1.0</pekko.version>
     </properties>
 
     <dependencies>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
+            <version>1.3.14</version>
         </dependency>
 
         <dependency>

--- a/pekko-sample-persistence-java/pom.xml
+++ b/pekko-sample-persistence-java/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>1.1.0</pekko.version>
+        <pekko.version>1.1.2</pekko.version>
     </properties>
 
     <dependencies>

--- a/pekko-sample-persistence-scala/build.sbt
+++ b/pekko-sample-persistence-scala/build.sbt
@@ -3,7 +3,7 @@ name := "pekko-sample-persistence-scala"
 
 scalaVersion := "2.13.15"
 
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val logbackVersion = "1.3.14"
 
 libraryDependencies ++= Seq(

--- a/pekko-sample-persistence-scala/build.sbt
+++ b/pekko-sample-persistence-scala/build.sbt
@@ -3,8 +3,8 @@ name := "pekko-sample-persistence-scala"
 
 scalaVersion := "2.13.15"
 
-val pekkoVersion = "1.0.3"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-persistence-typed" % pekkoVersion,

--- a/pekko-sample-sharding-java/build.sbt
+++ b/pekko-sample-sharding-java/build.sbt
@@ -1,4 +1,4 @@
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val pekkoHttpVersion = "1.1.0"
 val logbackVersion = "1.3.14"
 

--- a/pekko-sample-sharding-java/build.sbt
+++ b/pekko-sample-sharding-java/build.sbt
@@ -1,6 +1,6 @@
-val pekkoVersion = "1.0.3"
-val pekkoHttpVersion = "1.0.1"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val pekkoHttpVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 lazy val buildSettings = Seq(
   organization := "org.apache.pekko",

--- a/pekko-sample-sharding-java/killrweather-fog/pom.xml
+++ b/pekko-sample-sharding-java/killrweather-fog/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>1.1.0</pekko.version>
+        <pekko.version>1.1.2</pekko.version>
         <pekko-http.version>1.1.0</pekko-http.version>
     </properties>
 

--- a/pekko-sample-sharding-java/killrweather-fog/pom.xml
+++ b/pekko-sample-sharding-java/killrweather-fog/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>1.0.3</pekko.version>
-        <pekko-http.version>1.0.1</pekko-http.version>
+        <pekko.version>1.1.0</pekko.version>
+        <pekko-http.version>1.1.0</pekko-http.version>
     </properties>
 
     <repositories>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
+            <version>1.3.14</version>
         </dependency>
     </dependencies>
 

--- a/pekko-sample-sharding-java/killrweather/pom.xml
+++ b/pekko-sample-sharding-java/killrweather/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>1.1.0</pekko.version>
+        <pekko.version>1.1.2</pekko.version>
         <pekko-http.version>1.1.0</pekko-http.version>
     </properties>
 

--- a/pekko-sample-sharding-java/killrweather/pom.xml
+++ b/pekko-sample-sharding-java/killrweather/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>1.0.3</pekko.version>
-        <pekko-http.version>1.0.1</pekko-http.version>
+        <pekko.version>1.1.0</pekko.version>
+        <pekko-http.version>1.1.0</pekko-http.version>
     </properties>
 
     <repositories>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
+            <version>1.3.14</version>
         </dependency>
     </dependencies>
 

--- a/pekko-sample-sharding-scala/build.sbt
+++ b/pekko-sample-sharding-scala/build.sbt
@@ -1,4 +1,4 @@
-val pekkoVersion = "1.1.0"
+val pekkoVersion = "1.1.2"
 val pekkoHttpVersion = "1.1.0"
 val logbackVersion = "1.3.14"
 

--- a/pekko-sample-sharding-scala/build.sbt
+++ b/pekko-sample-sharding-scala/build.sbt
@@ -1,6 +1,6 @@
-val pekkoVersion = "1.0.3"
-val pekkoHttpVersion = "1.0.1"
-val logbackVersion = "1.2.13"
+val pekkoVersion = "1.1.0"
+val pekkoHttpVersion = "1.1.0"
+val logbackVersion = "1.3.14"
 
 lazy val buildSettings = Seq(
   organization := "org.apache.pekko",


### PR DESCRIPTION
Use Pekko 1.1 releases. Some M1 releases used where the full release not done yet - simpler than worrying about version mismatches that might occur if the Pekko 1.0 module is used instead.