### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
-version                                  = 3.9.3
-runner.dialect                           = scala213
+version                                  = 3.11.1
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -77,3 +77,13 @@ project.excludeFilters = [
   "scripts/authors.scala"
 ]
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/docs-gen/project/PekkoSamplePlugin.scala
+++ b/docs-gen/project/PekkoSamplePlugin.scala
@@ -53,7 +53,7 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
       outDir
     })
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     themeSettings ++
     propertiesSettings ++
     sourceDirectorySettings ++

--- a/pekko-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClient.scala
+++ b/pekko-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClient.scala
@@ -186,7 +186,7 @@ final class ClusterClient(settings: ClusterClientSettings)(
       val originalSender = sender()
       val session = sessionRef.get(originalSender) match {
         case Some(ses) => ses
-        case None =>
+        case None      =>
           val ses = newSession(
             settings,
             receptionistServiceClient,

--- a/pekko-sample-cluster-scala/src/main/scala/sample/cluster/stats/App.scala
+++ b/pekko-sample-cluster-scala/src/main/scala/sample/cluster/stats/App.scala
@@ -30,7 +30,8 @@ object App {
         val service = ctx.spawn(StatsService(workers), "StatsService")
 
         // published through the receptionist to the other nodes in the cluster
-        ctx.system.receptionist ! Receptionist
+        ctx.system.receptionist !
+        Receptionist
           .Register(StatsServiceKey, service)
       }
       if (cluster.selfMember.hasRole("client")) {

--- a/pekko-sample-cluster-scala/src/main/scala/sample/cluster/stats/AppOneMaster.scala
+++ b/pekko-sample-cluster-scala/src/main/scala/sample/cluster/stats/AppOneMaster.scala
@@ -46,7 +46,8 @@ object AppOneMaster {
         ctx.log.info("Starting {} workers", numberOfWorkers)
         (0 to numberOfWorkers).foreach { n =>
           val worker = ctx.spawn(StatsWorker(), s"StatsWorker$n")
-          ctx.system.receptionist ! Receptionist
+          ctx.system.receptionist !
+          Receptionist
             .Register(WorkerServiceKey, worker)
         }
       }

--- a/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/ReplicatedCache.scala
+++ b/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/ReplicatedCache.scala
@@ -57,7 +57,7 @@ object ReplicatedCache {
           replyTo ! Cached(key, g.dataValue.get(key))
           Behaviors.same
 
-        case InternalGetResponse(key, replyTo, _: NotFound[_]) =>
+        case InternalGetResponse(key, replyTo, _: NotFound[?]) =>
           replyTo ! Cached(key, None)
           Behaviors.same
 

--- a/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/ReplicatedMetrics.scala
+++ b/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/ReplicatedMetrics.scala
@@ -106,7 +106,7 @@ object ReplicatedMetrics {
               Behaviors.same
 
             case InternalSubscribeResponse(_)                 => Behaviors.same // ok
-            case InternalUpdateResponse(_: UpdateResponse[_]) => Behaviors.same // ok
+            case InternalUpdateResponse(_: UpdateResponse[?]) => Behaviors.same // ok
 
             case InternalClusterMemberUp(ClusterEvent.MemberUp(m)) =>
               nodesInCluster += nodeKey(m.address)

--- a/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/ShoppingCart.scala
+++ b/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/ShoppingCart.scala
@@ -125,10 +125,10 @@ object ShoppingCart {
       }
 
       def receiveOther: PartialFunction[Command, Behavior[Command]] = {
-        case InternalUpdateResponse(_: UpdateSuccess[_]) => Behaviors.same
-        case InternalUpdateResponse(_: UpdateTimeout[_]) => Behaviors.same
+        case InternalUpdateResponse(_: UpdateSuccess[?]) => Behaviors.same
+        case InternalUpdateResponse(_: UpdateTimeout[?]) => Behaviors.same
         // UpdateTimeout, will eventually be replicated
-        case InternalUpdateResponse(e: UpdateFailure[_]) => throw new IllegalStateException("Unexpected failure: " + e)
+        case InternalUpdateResponse(e: UpdateFailure[?]) => throw new IllegalStateException("Unexpected failure: " + e)
       }
 
       behavior

--- a/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/VotingService.scala
+++ b/pekko-sample-distributed-data-scala/src/main/scala/sample/distributeddata/VotingService.scala
@@ -71,7 +71,7 @@ object VotingService {
 
             Behaviors.same
 
-          case InternalUpdateResponse(_: UpdateSuccess[_]) => Behaviors.same
+          case InternalUpdateResponse(_: UpdateSuccess[?]) => Behaviors.same
 
           case Close =>
             replicatorFlag.askUpdate(
@@ -103,8 +103,8 @@ object VotingService {
             replyTo ! Votes(Map.empty, open)
             Behaviors.same
 
-          case InternalGetResponse(_, _: GetFailure[_])    => Behaviors.same
-          case InternalUpdateResponse(_: UpdateSuccess[_]) => Behaviors.same
+          case InternalGetResponse(_, _: GetFailure[?])    => Behaviors.same
+          case InternalUpdateResponse(_: UpdateSuccess[?]) => Behaviors.same
         }
 
         start

--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkManagerSingleton.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkManagerSingleton.scala
@@ -13,7 +13,7 @@ object WorkManagerSingleton {
   private val singletonName = "work-manager"
   private val singletonRole = "back-end"
 
-  def init(system: ActorSystem[_]): ActorRef[Command] = {
+  def init(system: ActorSystem[?]): ActorRef[Command] = {
     val workTimeout = system.settings.config.getDuration("distributed-workers.work-timeout").getSeconds.seconds
 
     ClusterSingleton(system).init(

--- a/pekko-sample-grpc-kubernetes-scala/http-to-grpc/src/main/scala/com/example/helloworld/HttpToGrpc.scala
+++ b/pekko-sample-grpc-kubernetes-scala/http-to-grpc/src/main/scala/com/example/helloworld/HttpToGrpc.scala
@@ -37,7 +37,7 @@ object HttpToGrpc {
           log.info("hello request")
           onComplete(client.sayHello(HelloRequest(name))) {
             case Success(reply) => complete(reply.message)
-            case Failure(t) =>
+            case Failure(t)     =>
               log.error(t, "Request failed")
               complete(StatusCodes.InternalServerError, t.getMessage)
           }

--- a/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/Main.scala
+++ b/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/Main.scala
@@ -95,7 +95,7 @@ object Main {
       }
 
     def startGrpc(
-        system: ActorSystem[_], frontEndPort: Int, region: ActorRef[UserEvents.Command]): Future[Http.ServerBinding] = {
+        system: ActorSystem[?], frontEndPort: Int, region: ActorRef[UserEvents.Command]): Future[Http.ServerBinding] = {
       val mat = Materializer.createMaterializer(system.toClassic)
       val service: HttpRequest => Future[HttpResponse] =
         UserServiceHandler(new UserGrpcService(system, region))(system.toClassic)

--- a/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEvents.scala
+++ b/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEvents.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 object UserEvents {
-  def init(system: ActorSystem[_], settings: ProcessorSettings): Future[ActorRef[Command]] = {
+  def init(system: ActorSystem[?], settings: ProcessorSettings): Future[ActorRef[Command]] = {
     import system.executionContext
     KafkaClusterSharding(settings.system).messageExtractorNoEnvelope(
       timeout = 10.seconds,

--- a/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEventsKafkaProcessor.scala
+++ b/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEventsKafkaProcessor.scala
@@ -33,7 +33,7 @@ object UserEventsKafkaProcessor {
   def apply(shardRegion: ActorRef[UserEvents.Command], processorSettings: ProcessorSettings): Behavior[Nothing] = {
     Behaviors
       .setup[Command] { ctx =>
-        implicit val sys: TypedActorSystem[_] = ctx.system
+        implicit val sys: TypedActorSystem[?] = ctx.system
         val result = startConsumingFromTopic(shardRegion, processorSettings)
 
         ctx.pipeToSelf(result) {
@@ -50,7 +50,7 @@ object UserEventsKafkaProcessor {
   }
 
   private def startConsumingFromTopic(shardRegion: ActorRef[UserEvents.Command], processorSettings: ProcessorSettings)(
-      implicit actorSystem: TypedActorSystem[_]): Future[Done] = {
+      implicit actorSystem: TypedActorSystem[?]): Future[Done] = {
 
     implicit val ec: ExecutionContext = actorSystem.executionContext
     implicit val scheduler: Scheduler = actorSystem.toClassic.scheduler

--- a/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserGrpcService.scala
+++ b/pekko-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserGrpcService.scala
@@ -8,7 +8,7 @@ import sample.sharding.kafka.UserEvents.{ Command, GetRunningTotal, RunningTotal
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
-class UserGrpcService(system: ActorSystem[_], shardRegion: ActorRef[Command]) extends UserService {
+class UserGrpcService(system: ActorSystem[?], shardRegion: ActorRef[Command]) extends UserService {
 
   implicit val timeout: Timeout = Timeout(5.seconds)
   implicit val sched: Scheduler = system.scheduler

--- a/pekko-sample-persistence-dc-scala/src/main/scala/sample/persistence/res/auction/Auction.scala
+++ b/pekko-sample-persistence-dc-scala/src/main/scala/sample/persistence/res/auction/Auction.scala
@@ -127,7 +127,8 @@ class Auction(
   }
 
   private def shouldClose(state: AuctionState): Boolean = {
-    responsibleForClosing && (state.phase match {
+    responsibleForClosing &&
+    (state.phase match {
       case Closing(alreadyFinishedAtDc) =>
         val allDone = MainApp.AllReplicas.diff(alreadyFinishedAtDc).isEmpty
         if (!allDone) {
@@ -238,7 +239,8 @@ object Auction {
       // If timestamps are equal, choose by dc where the offer was submitted
       // In real auctions, this last comparison should be deterministic but unpredictable, so that submitting to a
       // particular DC would not be an advantage.
-      (first.offer == second.offer && first.timestamp.equals(second.timestamp) && first.originReplica.id
+      (first.offer == second.offer && first.timestamp.equals(second.timestamp) &&
+      first.originReplica.id
         .compareTo(second.originReplica.id) < 0)
   }
 

--- a/pekko-sample-persistence-dc-scala/src/main/scala/sample/persistence/res/counter/ThumbsUpHttp.scala
+++ b/pekko-sample-persistence-dc-scala/src/main/scala/sample/persistence/res/counter/ThumbsUpHttp.scala
@@ -17,7 +17,7 @@ import scala.util.{ Failure, Success }
 object ThumbsUpHttp {
 
   def route(selfReplica: ReplicaId, res: ReplicatedSharding[ThumbsUpCounter.Command])(
-      implicit system: ActorSystem[_]): Route = {
+      implicit system: ActorSystem[?]): Route = {
 
     import org.apache.pekko.http.scaladsl.server.Directives._
 

--- a/pekko-sample-persistence-scala/src/main/scala/sample/persistence/ShoppingCart.scala
+++ b/pekko-sample-persistence-scala/src/main/scala/sample/persistence/ShoppingCart.scala
@@ -203,8 +203,8 @@ object ShoppingCart {
 
   private def handleEvent(state: State, event: Event) = {
     event match {
-      case ItemAdded(_, itemId, quantity) => state.updateItem(itemId, quantity)
-      case ItemRemoved(_, itemId)         => state.removeItem(itemId)
+      case ItemAdded(_, itemId, quantity)            => state.updateItem(itemId, quantity)
+      case ItemRemoved(_, itemId)                    => state.removeItem(itemId)
       case ItemQuantityAdjusted(_, itemId, quantity) =>
         state.updateItem(itemId, quantity)
       case CheckedOut(_, eventTime) => state.checkout(eventTime)

--- a/pekko-sample-sharding-scala/killrweather-fog/src/main/scala/sample/killrweather/fog/Fog.scala
+++ b/pekko-sample-sharding-scala/killrweather-fog/src/main/scala/sample/killrweather/fog/Fog.scala
@@ -45,7 +45,7 @@ object Guardian {
 
 object FogSettings {
 
-  def apply(system: ActorSystem[_]): FogSettings = {
+  def apply(system: ActorSystem[?]): FogSettings = {
     apply(system.settings.config.getConfig("killrweather.fog"))
   }
 

--- a/pekko-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherHttpServer.scala
+++ b/pekko-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherHttpServer.scala
@@ -14,7 +14,7 @@ private[killrweather] object WeatherHttpServer {
   /**
    * Logic to bind the given routes to a HTTP port and add some logging around it
    */
-  def start(routes: Route, port: Int, system: ActorSystem[_]): Unit = {
+  def start(routes: Route, port: Int, system: ActorSystem[?]): Unit = {
     import org.apache.pekko.actor.typed.scaladsl.adapter._
     implicit val classicSystem: classic.ActorSystem = system.toClassic
     val shutdown = CoordinatedShutdown(classicSystem)

--- a/pekko-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherRoutes.scala
+++ b/pekko-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherRoutes.scala
@@ -14,7 +14,7 @@ import org.apache.pekko.util.Timeout
  * 1. Receiving data from remote weather stations
  * 2. Receiving and responding to queries
  */
-private[killrweather] final class WeatherRoutes(system: ActorSystem[_]) {
+private[killrweather] final class WeatherRoutes(system: ActorSystem[?]) {
 
   private val sharding = ClusterSharding(system)
 

--- a/pekko-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherStation.scala
+++ b/pekko-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherStation.scala
@@ -31,7 +31,7 @@ private[killrweather] object WeatherStation {
   val TypeKey: EntityTypeKey[WeatherStation.Command] =
     EntityTypeKey[WeatherStation.Command]("WeatherStation")
 
-  def initSharding(system: ActorSystem[_]): Unit =
+  def initSharding(system: ActorSystem[?]): Unit =
     ClusterSharding(system).init(Entity(TypeKey) { entityContext =>
       WeatherStation(entityContext.entityId)
     })


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-samples.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048