### PR TITLE
fix: correct typos in sample projects

### DIFF
--- a/pekko-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/pekko-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -18,7 +18,7 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
   // note that this is not the same thing as cluster node roles
   val first = role("first")
   val second = role("second")
-  val third = role("thrid")
+  val third = role("third")
 
   // this configuration will be used for all nodes
   // note that no fixed host names and ports are used

--- a/pekko-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/pekko-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -25,7 +25,7 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
   // note that this is not the same thing as cluster node roles
   val first = role("first")
   val second = role("second")
-  val third = role("thrid")
+  val third = role("third")
 
   // this configuration will be used for all nodes
   // note that no fixed host names and ports are used

--- a/pekko-sample-distributed-workers-scala/README.md
+++ b/pekko-sample-distributed-workers-scala/README.md
@@ -191,7 +191,7 @@ Now that we have covered all the details, we can experiment with different sets 
 
 ## Experimenting
 
-When running the appliction without parameters it runs a six node cluster within the same JVM and starts a Apache Cassandra database. It can be more interesting to run them in separate processes. Open four terminal windows.
+When running the application without parameters it runs a six node cluster within the same JVM and starts a Apache Cassandra database. It can be more interesting to run them in separate processes. Open four terminal windows.
 
 In the first terminal window, start the Apache Cassandra database with the following command:
 


### PR DESCRIPTION
### Motivation
Typos found in sample project code and documentation.

### Modification
- `thrid`→`third` in StatsSampleSpec.scala (Java and Scala cluster samples)
- `apliction`→`application` in distributed-workers README

### Result
Cleaner sample code with corrected spelling.

### Tests
Not run - typo fixes only (test strings and docs)

### References
None - typo cleanup