### PR TITLE
refactor: modernize Java example code with Java 17 features

### DIFF
--- a/pekko-sample-cluster-client-grpc-java/src/main/java/sample/cluster/client/grpc/ClusterClient.java
+++ b/pekko-sample-cluster-client-grpc-java/src/main/java/sample/cluster/client/grpc/ClusterClient.java
@@ -70,17 +70,7 @@ public class ClusterClient extends AbstractLoggingActor {
 
   public interface Command {}
 
-  public static class Send implements Command {
-    public final String path;
-    public final Object msg;
-    public final boolean localAffinity;
-
-    public Send(String path, Object msg, boolean localAffinity) {
-      this.path = path;
-      this.msg = msg;
-      this.localAffinity = localAffinity;
-    }
-
+  public record Send(String path, Object msg, boolean localAffinity) implements Command {
     /**
      * Convenience constructor with `localAffinity` false
      */
@@ -92,17 +82,7 @@ public class ClusterClient extends AbstractLoggingActor {
   /**
    * More efficient than `Send` for single request-reply interaction
    */
-  public static class SendAsk implements Command {
-    public final String path;
-    public final Object msg;
-    public final boolean localAffinity;
-
-    public SendAsk(String path, Object msg, boolean localAffinity) {
-      this.path = path;
-      this.msg = msg;
-      this.localAffinity = localAffinity;
-    }
-
+  public record SendAsk(String path, Object msg, boolean localAffinity) implements Command {
     /**
      * Convenience constructor with `localAffinity` false
      */
@@ -111,25 +91,9 @@ public class ClusterClient extends AbstractLoggingActor {
     }
   }
 
-  public static class SendToAll implements Command {
-    public final String path;
-    public final Object msg;
+  public record SendToAll(String path, Object msg) implements Command {}
 
-    public SendToAll(String path, Object msg) {
-      this.path = path;
-      this.msg = msg;
-    }
-  }
-
-  public static class Publish implements Command {
-    public final String topic;
-    public final Object msg;
-
-    public Publish(String topic, Object msg) {
-      this.topic = topic;
-      this.msg = msg;
-    }
-  }
+  public record Publish(String topic, Object msg) implements Command {}
 
   private static ClusterClientReceptionistServiceClient createClientStub(ClusterClientSettings settings,
       Materializer mat) {
@@ -161,29 +125,26 @@ public class ClusterClient extends AbstractLoggingActor {
             )
           .via(killSwitch.flow())
           .map(msg -> {
-            if (msg instanceof Send) {
-              Send send = (Send) msg;
-              Payload payload = serialization.serializePayload(send.msg);
+            if (msg instanceof Send send) {
+              Payload payload = serialization.serializePayload(send.msg());
               return Req.newBuilder()
                 .setSend(SendReq.newBuilder()
-                  .setPath(send.path)
-                  .setLocalAffinity(send.localAffinity)
+                  .setPath(send.path())
+                  .setLocalAffinity(send.localAffinity())
                   .setPayload(payload))
                   .build();
-            } else if (msg instanceof SendToAll) {
-              SendToAll sendToAll = (SendToAll) msg;
-              Payload payload = serialization.serializePayload(sendToAll.msg);
+            } else if (msg instanceof SendToAll sendToAll) {
+              Payload payload = serialization.serializePayload(sendToAll.msg());
               return Req.newBuilder()
                 .setSendToAll(SendToAllReq.newBuilder()
-                  .setPath(sendToAll.path)
+                  .setPath(sendToAll.path())
                   .setPayload(payload))
                   .build();
-            } else if (msg instanceof Publish) {
-              Publish publish = (Publish) msg;
-              Payload payload = serialization.serializePayload(publish.msg);
+            } else if (msg instanceof Publish publish) {
+              Payload payload = serialization.serializePayload(publish.msg());
               return Req.newBuilder()
                 .setPublish(PublishReq.newBuilder()
-                  .setTopic(publish.topic)
+                  .setTopic(publish.topic())
                   .setPayload(payload))
                   .build();
             } else {
@@ -216,10 +177,10 @@ public class ClusterClient extends AbstractLoggingActor {
     ClusterClientReceptionistServiceClient receptionistServiceClient,
     SendAsk send,
     ClusterClientSerialization serialization) {
-    Payload payload = serialization.serializePayload(send.msg);
+    Payload payload = serialization.serializePayload(send.msg());
     SendReq sendReq = SendReq.newBuilder()
-      .setPath(send.path)
-      .setLocalAffinity(send.localAffinity)
+      .setPath(send.path())
+      .setLocalAffinity(send.localAffinity())
       .setPayload(payload)
       .build();
     return receptionistServiceClient.askSend(sendReq).thenApply( rsp ->

--- a/pekko-sample-distributed-data-java/src/main/java/sample/distributeddata/ReplicatedCache.java
+++ b/pekko-sample-distributed-data-java/src/main/java/sample/distributeddata/ReplicatedCache.java
@@ -27,104 +27,26 @@ public class ReplicatedCache {
 
   public interface Command {}
 
-  public static class PutInCache implements Command {
-    public final String key;
-    public final String value;
+  public record PutInCache(String key, String value) implements Command {}
 
-    public PutInCache(String key, String value) {
-      this.key = key;
-      this.value = value;
-    }
-  }
+  public record GetFromCache(String key, ActorRef<Cached> replyTo) implements Command {}
 
-  public static class GetFromCache implements Command {
-    public final String key;
-    public final ActorRef<Cached> replyTo;
-
-    public GetFromCache(String key, ActorRef<Cached> replyTo) {
-      this.key = key;
-      this.replyTo = replyTo;
-    }
-  }
-
-  public static class Cached {
-    public final String key;
-    public final Optional<String> value;
-
-    public Cached(String key, Optional<String> value) {
-      this.key = key;
-      this.value = value;
-    }
-
-    @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((key == null) ? 0 : key.hashCode());
-      result = prime * result + ((value == null) ? 0 : value.hashCode());
-      return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj)
-        return true;
-      if (obj == null)
-        return false;
-      if (getClass() != obj.getClass())
-        return false;
-      Cached other = (Cached) obj;
-      if (key == null) {
-        if (other.key != null)
-          return false;
-      } else if (!key.equals(other.key))
-        return false;
-      if (value == null) {
-        if (other.value != null)
-          return false;
-      } else if (!value.equals(other.value))
-        return false;
-      return true;
-    }
-
+  public record Cached(String key, Optional<String> value) {
     @Override
     public String toString() {
       return "Cached [key=" + key + ", value=" + value + "]";
     }
-
   }
 
-  public static class Evict implements Command {
-    public final String key;
-
-    public Evict(String key) {
-      this.key = key;
-    }
-  }
+  public record Evict(String key) implements Command {}
 
   private interface InternalCommand extends Command {}
 
-  private static class InternalGetResponse implements InternalCommand {
-    public final String key;
-    public final ActorRef<Cached> replyTo;
-    public final GetResponse<LWWMap<String, String>> rsp;
+  private record InternalGetResponse(String key, ActorRef<Cached> replyTo, GetResponse<LWWMap<String, String>> rsp)
+      implements InternalCommand {}
 
-    private InternalGetResponse(
-        String key, ActorRef<Cached> replyTo, GetResponse<LWWMap<String, String>> rsp
-    ) {
-      this.key = key;
-      this.replyTo = replyTo;
-      this.rsp = rsp;
-    }
-  }
-
-  private static class InternalUpdateResponse implements InternalCommand {
-    public final UpdateResponse<LWWMap<String, String>> rsp;
-
-    private InternalUpdateResponse(UpdateResponse<LWWMap<String, String>> rsp) {
-      this.rsp = rsp;
-    }
-  }
+  private record InternalUpdateResponse(UpdateResponse<LWWMap<String, String>> rsp)
+      implements InternalCommand {}
 
   public static Behavior<Command> create() {
     return Behaviors.setup(context ->
@@ -147,9 +69,9 @@ public class ReplicatedCache {
   public Behavior<Command> createBehavior() {
     return Behaviors
         .receive(Command.class)
-        .onMessage(PutInCache.class, cmd -> receivePutInCache(cmd.key, cmd.value))
-        .onMessage(Evict.class, cmd -> receiveEvict(cmd.key))
-        .onMessage(GetFromCache.class, cmd -> receiveGetFromCache(cmd.key, cmd.replyTo))
+        .onMessage(PutInCache.class, cmd -> receivePutInCache(cmd.key(), cmd.value()))
+        .onMessage(Evict.class, cmd -> receiveEvict(cmd.key()))
+        .onMessage(GetFromCache.class, cmd -> receiveGetFromCache(cmd.key(), cmd.replyTo()))
         .onMessage(InternalGetResponse.class, this::onInternalGetResponse)
         .onMessage(InternalUpdateResponse.class, notUsed -> Behaviors.same())
         .build();
@@ -194,12 +116,12 @@ public class ReplicatedCache {
   }
 
   private Behavior<Command> onInternalGetResponse(InternalGetResponse msg) {
-    if (msg.rsp instanceof GetSuccess) {
-      Option<String> valueOption = ((GetSuccess<LWWMap<String, String>>) msg.rsp).get(dataKey(msg.key)).get(msg.key);
+    if (msg.rsp() instanceof GetSuccess<LWWMap<String, String>> success) {
+      Option<String> valueOption = success.get(dataKey(msg.key())).get(msg.key());
       Optional<String> valueOptional = Optional.ofNullable(valueOption.isDefined() ? valueOption.get() : null);
-      msg.replyTo.tell(new Cached(msg.key, valueOptional));
-    } else if (msg.rsp instanceof NotFound) {
-      msg.replyTo.tell(new Cached(msg.key, Optional.empty()));
+      msg.replyTo().tell(new Cached(msg.key(), valueOptional));
+    } else if (msg.rsp() instanceof NotFound) {
+      msg.replyTo().tell(new Cached(msg.key(), Optional.empty()));
     }
     return Behaviors.same();
   }

--- a/pekko-sample-distributed-data-java/src/main/java/sample/distributeddata/ShoppingCart.java
+++ b/pekko-sample-distributed-data-java/src/main/java/sample/distributeddata/ShoppingCart.java
@@ -42,119 +42,31 @@ public class ShoppingCart {
 
   public interface Command {}
 
-  public static final class GetCart implements Command {
-    public final ActorRef<Cart> replyTo;
+  public record GetCart(ActorRef<Cart> replyTo) implements Command {}
 
-    public GetCart(ActorRef<Cart> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record AddItem(LineItem item) implements Command {}
 
-  public static class AddItem implements Command {
-    public final LineItem item;
+  public record RemoveItem(String productId) implements Command {}
 
-    public AddItem(LineItem item) {
-      this.item = item;
-    }
-  }
+  public record Cart(Set<LineItem> items) {}
 
-  public static class RemoveItem implements Command {
-    public final String productId;
-
-    public RemoveItem(String productId) {
-      this.productId = productId;
-    }
-  }
-
-  public static class Cart {
-    public final Set<LineItem> items;
-
-    public Cart(Set<LineItem> items) {
-      this.items = items;
-    }
-  }
-
-  public static class LineItem {
-    public final String productId;
-    public final String title;
-    public final int quantity;
-
-    public LineItem(String productId, String title, int quantity) {
-      this.productId = productId;
-      this.title = title;
-      this.quantity = quantity;
-    }
-
-    @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((productId == null) ? 0 : productId.hashCode());
-      result = prime * result + quantity;
-      result = prime * result + ((title == null) ? 0 : title.hashCode());
-      return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj)
-        return true;
-      if (obj == null)
-        return false;
-      if (getClass() != obj.getClass())
-        return false;
-      LineItem other = (LineItem) obj;
-      if (productId == null) {
-        if (other.productId != null)
-          return false;
-      } else if (!productId.equals(other.productId))
-        return false;
-      if (quantity != other.quantity)
-        return false;
-      if (title == null) {
-        if (other.title != null)
-          return false;
-      } else if (!title.equals(other.title))
-        return false;
-      return true;
-    }
-
+  public record LineItem(String productId, String title, int quantity) {
     @Override
     public String toString() {
       return "LineItem [productId=" + productId + ", title=" + title + ", quantity=" + quantity + "]";
     }
-
   }
 
   private interface InternalCommand extends Command {}
 
-  private static class InternalGetResponse implements InternalCommand {
-    public final GetResponse<LWWMap<String, LineItem>> rsp;
-    public final ActorRef<Cart> replyTo;
+  private record InternalGetResponse(GetResponse<LWWMap<String, LineItem>> rsp, ActorRef<Cart> replyTo)
+      implements InternalCommand {}
 
-    private InternalGetResponse(GetResponse<LWWMap<String, LineItem>> rsp, ActorRef<Cart> replyTo) {
-      this.rsp = rsp;
-      this.replyTo = replyTo;
-    }
-  }
+  private record InternalUpdateResponse<A extends ReplicatedData>(UpdateResponse<A> rsp)
+      implements InternalCommand {}
 
-  private static class InternalUpdateResponse<A extends ReplicatedData> implements InternalCommand {
-    public final UpdateResponse<A> rsp;
-
-    private InternalUpdateResponse(UpdateResponse<A> rsp) {
-      this.rsp = rsp;
-    }
-  }
-
-  private static class InternalRemoveItem implements InternalCommand {
-    public final String productId;
-    public final GetResponse<LWWMap<String, LineItem>> rsp;
-
-    private InternalRemoveItem(String productId, GetResponse<LWWMap<String, LineItem>> rsp) {
-      this.productId = productId;
-      this.rsp = rsp;
-    }
-  }
+  private record InternalRemoveItem(String productId, GetResponse<LWWMap<String, LineItem>> rsp)
+      implements InternalCommand {}
 
   public static Behavior<Command> create(String userId) {
     return Behaviors.setup(context ->
@@ -193,22 +105,22 @@ public class ShoppingCart {
   private Behavior<Command> onGetCart(GetCart command) {
     replicator.askGet(
         askReplyTo -> new Get<>(dataKey, readMajority, askReplyTo),
-        rsp -> new InternalGetResponse(rsp, command.replyTo));
+        rsp -> new InternalGetResponse(rsp, command.replyTo()));
 
     return Behaviors.same();
   }
 
   private Behavior<Command> onInternalGetResponse(InternalGetResponse msg) {
-    if (msg.rsp instanceof GetSuccess) {
-      LWWMap<String, LineItem> data = ((GetSuccess<LWWMap<String, LineItem>>) msg.rsp).get(dataKey);
-      msg.replyTo.tell(new Cart(new HashSet<>(data.getEntries().values())));
-    } else if (msg.rsp instanceof NotFound) {
-      msg.replyTo.tell(new Cart(new HashSet<>()));
-    } else if (msg.rsp instanceof GetFailure) {
+    if (msg.rsp() instanceof GetSuccess<LWWMap<String, LineItem>> success) {
+      LWWMap<String, LineItem> data = success.get(dataKey);
+      msg.replyTo().tell(new Cart(new HashSet<>(data.getEntries().values())));
+    } else if (msg.rsp() instanceof NotFound) {
+      msg.replyTo().tell(new Cart(new HashSet<>()));
+    } else if (msg.rsp() instanceof GetFailure) {
       // ReadMajority failure, try again with local read
       replicator.askGet(
           askReplyTo -> new Get<>(dataKey, Replicator.readLocal(), askReplyTo),
-          rsp -> new InternalGetResponse(rsp, msg.replyTo)
+          rsp -> new InternalGetResponse(rsp, msg.replyTo())
       );
     }
     return Behaviors.same();
@@ -224,7 +136,7 @@ public class ShoppingCart {
                 LWWMap.empty(),
                 writeMajority,
                 askReplyTo,
-                cart -> updateCart(cart, command.item)
+                cart -> updateCart(cart, command.item())
             ),
         InternalUpdateResponse::new);
 
@@ -234,13 +146,13 @@ public class ShoppingCart {
   //#add-item
 
   private LWWMap<String, LineItem> updateCart(LWWMap<String, LineItem> data, LineItem item) {
-    if (data.contains(item.productId)) {
-      LineItem existingItem = data.get(item.productId).get();
-      int newQuantity = existingItem.quantity + item.quantity;
-      LineItem newItem = new LineItem(item.productId, item.title, newQuantity);
-      return data.put(node, item.productId, newItem);
+    if (data.contains(item.productId())) {
+      LineItem existingItem = data.get(item.productId()).get();
+      int newQuantity = existingItem.quantity() + item.quantity();
+      LineItem newItem = new LineItem(item.productId(), item.title(), newQuantity);
+      return data.put(node, item.productId(), newItem);
     } else {
-      return data.put(node, item.productId, item);
+      return data.put(node, item.productId(), item);
     }
   }
 
@@ -250,19 +162,19 @@ public class ShoppingCart {
     // remove must have seen the item to be able to remove it.
     replicator.askGet(
         askReplyTo -> new Get<>(dataKey, readMajority, askReplyTo),
-        rsp -> new InternalRemoveItem(command.productId, rsp));
+        rsp -> new InternalRemoveItem(command.productId(), rsp));
 
     return Behaviors.same();
   }
 
   private Behavior<Command> onInternalRemoveItem(InternalRemoveItem msg) {
-    if (msg.rsp instanceof GetSuccess) {
-      removeItem(msg.productId);
-    } else if (msg.rsp instanceof NotFound) {
+    if (msg.rsp() instanceof GetSuccess) {
+      removeItem(msg.productId());
+    } else if (msg.rsp() instanceof NotFound) {
       /* nothing to remove */
-    } else if (msg.rsp instanceof GetFailure) {
+    } else if (msg.rsp() instanceof GetFailure) {
       // ReadMajority failed, fall back to best effort local value
-      removeItem(msg.productId);
+      removeItem(msg.productId());
     }
     return Behaviors.same();
   }
@@ -282,12 +194,12 @@ public class ShoppingCart {
   //#remove-item
 
   private Behavior<Command> onInternalUpdateResponse(InternalUpdateResponse<?> msg) {
-    if (msg.rsp instanceof UpdateSuccess) {
+    if (msg.rsp() instanceof UpdateSuccess) {
       // ok
-    } else if (msg.rsp instanceof UpdateTimeout) {
+    } else if (msg.rsp() instanceof UpdateTimeout) {
       // will eventually be replicated
-    } else if (msg.rsp instanceof UpdateFailure) {
-      throw new IllegalStateException("Unexpected failure: " + msg.rsp);
+    } else if (msg.rsp() instanceof UpdateFailure) {
+      throw new IllegalStateException("Unexpected failure: " + msg.rsp());
     }
     return Behaviors.same();
   }

--- a/pekko-sample-distributed-data-java/src/main/java/sample/distributeddata/VotingService.java
+++ b/pekko-sample-distributed-data-java/src/main/java/sample/distributeddata/VotingService.java
@@ -38,49 +38,20 @@ public class VotingService {
     }
   }
 
-  public static class Vote implements Command {
-    public final String participant;
+  public record Vote(String participant) implements Command {}
 
-    public Vote(String participant) {
-      this.participant = participant;
-    }
-  }
-
-  public static class GetVotes implements Command {
-    public final ActorRef<Votes> replyTo;
-
-    public GetVotes(ActorRef<Votes> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record GetVotes(ActorRef<Votes> replyTo) implements Command {}
 
   private interface InternalCommand extends Command {}
 
-  private static class InternalSubscribeResponse implements InternalCommand {
-    public final SubscribeResponse<Flag> rsp;
+  private record InternalSubscribeResponse(SubscribeResponse<Flag> rsp)
+      implements InternalCommand {}
 
-    private InternalSubscribeResponse(SubscribeResponse<Flag> rsp) {
-      this.rsp = rsp;
-    }
-  }
+  private record InternalUpdateResponse<A extends ReplicatedData>(UpdateResponse<A> rsp)
+      implements InternalCommand {}
 
-  private static class InternalUpdateResponse<A extends ReplicatedData> implements InternalCommand {
-    public final UpdateResponse<A> rsp;
-
-    private InternalUpdateResponse(UpdateResponse<A> rsp) {
-      this.rsp = rsp;
-    }
-  }
-
-  private static class InternalGetResponse implements InternalCommand {
-    public final ActorRef<Votes> replyTo;
-    public final GetResponse<PNCounterMap<String>> rsp;
-
-    private InternalGetResponse(ActorRef<Votes> replyTo, GetResponse<PNCounterMap<String>> rsp) {
-      this.replyTo = replyTo;
-      this.rsp = rsp;
-    }
-  }
+  private record InternalGetResponse(ActorRef<Votes> replyTo, GetResponse<PNCounterMap<String>> rsp)
+      implements InternalCommand {}
 
   private final ReplicatorMessageAdapter<Command, Flag> replicatorFlag;
   private final ReplicatorMessageAdapter<Command, PNCounterMap<String>> replicatorCounters;
@@ -140,7 +111,7 @@ public class VotingService {
   }
 
   private Behavior<Command> receiveGetVotesEmpty(GetVotes getVotes) {
-    getVotes.replyTo.tell(new Votes(new HashMap<>(), false));
+    getVotes.replyTo().tell(new Votes(new HashMap<>(), false));
     return Behaviors.same();
   }
 
@@ -156,7 +127,7 @@ public class VotingService {
   private Behavior<Command> receiveVote(Vote vote) {
     replicatorCounters.askUpdate(
         askReplyTo -> new Update<>(countersKey, PNCounterMap.create(), writeLocal(), askReplyTo,
-            curr -> curr.increment(node, vote.participant, 1)),
+            curr -> curr.increment(node, vote.participant(), 1)),
         InternalUpdateResponse::new);
 
     return Behaviors.same();
@@ -171,12 +142,12 @@ public class VotingService {
   }
 
   private Behavior<Command> onInternalSubscribeResponse(InternalSubscribeResponse rsp) {
-    if (rsp.rsp instanceof Changed && rsp.rsp.key().equals(openedKey)) {
-      if (((Changed<Flag>) rsp.rsp).dataValue().enabled()) {
+    if (rsp.rsp() instanceof Changed<Flag> changed && rsp.rsp().key().equals(openedKey)) {
+      if (changed.dataValue().enabled()) {
         return becomeOpen();
       }
-    } else if (rsp.rsp instanceof Changed && rsp.rsp.key().equals(closedKey)) {
-      if (((Changed<Flag>) rsp.rsp).dataValue().enabled()) {
+    } else if (rsp.rsp() instanceof Changed<Flag> changed2 && rsp.rsp().key().equals(closedKey)) {
+      if (changed2.dataValue().enabled()) {
         return matchGetVotes(false);
       }
     }
@@ -198,19 +169,18 @@ public class VotingService {
   private Behavior<Command> receiveGetVotes(GetVotes getVotes) {
     replicatorCounters.askGet(
         askReplyTo -> new Get<>(countersKey, readAll, askReplyTo),
-        rsp -> new InternalGetResponse(getVotes.replyTo, rsp)
+        rsp -> new InternalGetResponse(getVotes.replyTo(), rsp)
     );
     return Behaviors.same();
   }
 
   private Behavior<Command> onInternalGetResponse(boolean open, InternalGetResponse rsp) {
-    if (rsp.rsp instanceof GetSuccess && rsp.rsp.key().equals(countersKey)) {
-      GetSuccess<PNCounterMap<String>> rsp1 = (GetSuccess<PNCounterMap<String>>) rsp.rsp;
-      Map<String, BigInteger> result = rsp1.dataValue().getEntries();
-      rsp.replyTo.tell(new Votes(result, open));
-    } else if (rsp.rsp instanceof NotFound && rsp.rsp.key().equals(countersKey)) {
-      rsp.replyTo.tell(new Votes(new HashMap<>(), open));
-    } else if (rsp.rsp instanceof GetFailure && rsp.rsp.key().equals(countersKey)) {
+    if (rsp.rsp() instanceof GetSuccess<PNCounterMap<String>> success && rsp.rsp().key().equals(countersKey)) {
+      Map<String, BigInteger> result = success.dataValue().getEntries();
+      rsp.replyTo().tell(new Votes(result, open));
+    } else if (rsp.rsp() instanceof NotFound && rsp.rsp().key().equals(countersKey)) {
+      rsp.replyTo().tell(new Votes(new HashMap<>(), open));
+    } else if (rsp.rsp() instanceof GetFailure && rsp.rsp().key().equals(countersKey)) {
       // skip
     }
     return Behaviors.same();

--- a/pekko-sample-persistence-dc-java/src/main/java/sample/persistence/res/counter/ThumbsUpCounter.java
+++ b/pekko-sample-persistence-dc-java/src/main/java/sample/persistence/res/counter/ThumbsUpCounter.java
@@ -42,14 +42,14 @@ public final class ThumbsUpCounter extends ReplicatedEventSourcedBehavior<Thumbs
     @Override
     public CommandHandler<Command, Event, State> commandHandler() {
         return newCommandHandlerBuilder().forAnyState()
-                .onCommand(GiveThumbsUp.class, (state, cmd) -> Effect().persist(new GaveThumbsUp(cmd.userId)).thenRun(state2 -> {
-                    ctx.getLog().info("Thumbs-up by {}, total count {}", cmd.userId, state2.users.size());
-                    cmd.replyTo.tell((long) state2.users.size());
+                .onCommand(GiveThumbsUp.class, (state, cmd) -> Effect().persist(new GaveThumbsUp(cmd.userId())).thenRun(state2 -> {
+                    ctx.getLog().info("Thumbs-up by {}, total count {}", cmd.userId(), state2.users.size());
+                    cmd.replyTo().tell((long) state2.users.size());
                 })).onCommand(GetCount.class, (state, cmd) -> {
-                    cmd.replyTo.tell((long) state.users.size());
+                    cmd.replyTo().tell((long) state.users.size());
                     return Effect().none();
                 }).onCommand(GetUsers.class, (state, cmd) -> {
-                    cmd.replyTo.tell(state);
+                    cmd.replyTo().tell(state);
                     return Effect().none();
                 }).build();
     }
@@ -58,7 +58,7 @@ public final class ThumbsUpCounter extends ReplicatedEventSourcedBehavior<Thumbs
     public EventHandler<State, Event> eventHandler() {
         return newEventHandlerBuilder().forAnyState()
                 .onEvent(GaveThumbsUp.class, (state, event) ->
-                        state.add(event.userId)
+                        state.add(event.userId())
                 ).build();
 
     }
@@ -68,50 +68,18 @@ public final class ThumbsUpCounter extends ReplicatedEventSourcedBehavior<Thumbs
     public interface Command extends CborSerializable {
     }
 
-    public static class GiveThumbsUp implements Command {
-        public final String resourceId;
-        public final String userId;
-        public final ActorRef<Long> replyTo;
+    public record GiveThumbsUp(String resourceId, String userId, ActorRef<Long> replyTo)
+        implements Command {}
 
-        public GiveThumbsUp(String resourceId, String userId, ActorRef<Long> replyTo) {
-            this.resourceId = resourceId;
-            this.userId = userId;
-            this.replyTo = replyTo;
-        }
-    }
+    public record GetCount(String resourceId, ActorRef<Long> replyTo) implements Command {}
 
-    public static class GetCount implements Command {
-        public final String resourceId;
-        public final ActorRef<Long> replyTo;
-
-        public GetCount(String resourceId, ActorRef<Long> replyTo) {
-            this.resourceId = resourceId;
-            this.replyTo = replyTo;
-        }
-    }
-
-    public static class GetUsers implements Command {
-        public final String resourceId;
-        public final ActorRef<State> replyTo;
-
-        public GetUsers(String resourceId, ActorRef<State> replyTo) {
-            this.resourceId = resourceId;
-            this.replyTo = replyTo;
-        }
-    }
+    public record GetUsers(String resourceId, ActorRef<State> replyTo) implements Command {}
 
 
     interface Event extends CborSerializable {
     }
 
-    public static class GaveThumbsUp implements Event {
-        public final String userId;
-
-        @JsonCreator
-        public GaveThumbsUp(String userId) {
-            this.userId = userId;
-        }
-    }
+    public record GaveThumbsUp(String userId) implements Event {}
 
     public static class State implements CborSerializable {
         public final Set<String> users;

--- a/pekko-sample-persistence-java/src/main/java/sample/persistence/ShoppingCart.java
+++ b/pekko-sample-persistence-java/src/main/java/sample/persistence/ShoppingCart.java
@@ -11,7 +11,6 @@ import org.apache.pekko.persistence.typed.javadsl.Effect;
 import org.apache.pekko.persistence.typed.javadsl.EventHandler;
 import org.apache.pekko.persistence.typed.javadsl.EventSourcedBehavior;
 import org.apache.pekko.persistence.typed.javadsl.RetentionCriteria;
-import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -97,60 +96,27 @@ public class ShoppingCart
    * It can reply with `StatusReply<Summary>`, which is sent back to the caller when
    * all the events emitted by this command are successfully persisted.
    */
-  public static class AddItem implements Command {
-    public final String itemId;
-    public final int quantity;
-    public final ActorRef<StatusReply<Summary>> replyTo;
-
-    public AddItem(String itemId, int quantity, ActorRef<StatusReply<Summary>> replyTo) {
-      this.itemId = itemId;
-      this.quantity = quantity;
-      this.replyTo = replyTo;
-    }
-  }
+  public record AddItem(String itemId, int quantity, ActorRef<StatusReply<Summary>> replyTo)
+      implements Command {}
 
   /**
    * A command to remove an item from the cart.
    */
-  public static class RemoveItem implements Command {
-    public final String itemId;
-    public final ActorRef<StatusReply<Summary>> replyTo;
-
-    @JsonCreator
-    public RemoveItem(String itemId, ActorRef<StatusReply<Summary>> replyTo) {
-      this.itemId = itemId;
-      this.replyTo = replyTo;
-    }
-  }
+  public record RemoveItem(String itemId, ActorRef<StatusReply<Summary>> replyTo)
+      implements Command {}
 
   /**
    * A command to adjust the quantity of an item in the cart.
    */
-  public static class AdjustItemQuantity implements Command {
-    public final String itemId;
-    public final int quantity;
-    public final ActorRef<StatusReply<Summary>> replyTo;
-
-    public AdjustItemQuantity(String itemId, int quantity, ActorRef<StatusReply<Summary>> replyTo) {
-      this.itemId = itemId;
-      this.quantity = quantity;
-      this.replyTo = replyTo;
-    }
-  }
+  public record AdjustItemQuantity(String itemId, int quantity, ActorRef<StatusReply<Summary>> replyTo)
+      implements Command {}
 
   /**
    * A command to get the current state of the shopping cart.
    *
    * The reply type is the {@link Summary}
    */
-  public static class Get implements Command {
-    public final ActorRef<Summary> replyTo;
-
-    @JsonCreator
-    public Get(ActorRef<Summary> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record Get(ActorRef<Summary> replyTo) implements Command {}
 
   /**
    * A command to checkout the shopping cart.
@@ -158,92 +124,42 @@ public class ShoppingCart
    * The reply type is the {@link StatusReply<Summary>}, which will be returned when the events have been
    * emitted.
    */
-  public static class Checkout implements Command {
-    public final ActorRef<StatusReply<Summary>> replyTo;
-
-    @JsonCreator
-    public Checkout(ActorRef<StatusReply<Summary>> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record Checkout(ActorRef<StatusReply<Summary>> replyTo) implements Command {}
 
   /**
    * Summary of the shopping cart state, used in reply messages.
    */
-  public static final class Summary implements CborSerializable {
-    public final Map<String, Integer> items;
-    public final boolean checkedOut;
-
-
-    public Summary(Map<String, Integer> items, boolean checkedOut) {
-      // Summary is included in messages and should therefore be immutable
-      this.items = Collections.unmodifiableMap(new HashMap<>(items));
-      this.checkedOut = checkedOut;
+  public record Summary(Map<String, Integer> items, boolean checkedOut) implements CborSerializable {
+    public Summary {
+      items = Collections.unmodifiableMap(new HashMap<>(items));
     }
   }
-  
+
   public interface Event extends CborSerializable {
   }
 
-  public static final class ItemAdded implements Event {
-    public final String cartId;
-    public final String itemId;
-    public final int quantity;
-
-    public ItemAdded(String cartId, String itemId, int quantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.quantity = quantity;
-    }
-
+  public record ItemAdded(String cartId, String itemId, int quantity) implements Event {
     @Override
     public String toString() {
       return "ItemAdded(" + cartId + "," + itemId + "," + quantity + ")";
     }
   }
 
-  public static final class ItemRemoved implements Event {
-    public final String cartId;
-    public final String itemId;
-
-    public ItemRemoved(String cartId, String itemId) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-    }
-
+  public record ItemRemoved(String cartId, String itemId) implements Event {
     @Override
     public String toString() {
       return "ItemRemoved(" + cartId + "," + itemId + ")";
     }
   }
 
-  public static final class ItemQuantityAdjusted implements Event {
-    public final String cartId;
-    public final String itemId;
-    public final int quantity;
-
-    public ItemQuantityAdjusted(String cartId, String itemId, int quantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.quantity = quantity;
-    }
-
+  public record ItemQuantityAdjusted(String cartId, String itemId, int quantity) implements Event {
     @Override
     public String toString() {
       return "ItemQuantityAdjusted(" + cartId + "," + itemId + "," + quantity + ")";
     }
   }
 
-  public static class CheckedOut implements Event {
-
-    public final String cartId;
-    public final Instant eventTime;
-
-    public CheckedOut(String cartId, Instant eventTime) {
-      this.cartId = cartId;
-      this.eventTime = eventTime;
-    }
-
+  public record CheckedOut(String cartId, Instant eventTime) implements Event {
     @Override
     public String toString() {
       return "CheckedOut(" + cartId + "," + eventTime + ")";
@@ -294,79 +210,79 @@ public class ShoppingCart
   }
 
   private Effect<Event, State> onGet(State state, Get cmd) {
-    cmd.replyTo.tell(state.toSummary());
+    cmd.replyTo().tell(state.toSummary());
     return Effect().none();
   }
 
   private class OpenShoppingCartCommandHandlers {
 
     Effect<Event, State> onAddItem(State state, AddItem cmd) {
-      if (state.hasItem(cmd.itemId)) {
-        cmd.replyTo.tell(StatusReply.error(
-          "Item '" + cmd.itemId + "' was already added to this shopping cart"));
+      if (state.hasItem(cmd.itemId())) {
+        cmd.replyTo().tell(StatusReply.error(
+          "Item '" + cmd.itemId() + "' was already added to this shopping cart"));
         return Effect().none();
-      } else if (cmd.quantity <= 0) {
-        cmd.replyTo.tell(StatusReply.error("Quantity must be greater than zero"));
+      } else if (cmd.quantity() <= 0) {
+        cmd.replyTo().tell(StatusReply.error("Quantity must be greater than zero"));
         return Effect().none();
       } else {
-        return Effect().persist(new ItemAdded(cartId, cmd.itemId, cmd.quantity))
-          .thenRun(updatedCart -> cmd.replyTo.tell(StatusReply.success(updatedCart.toSummary())));
+        return Effect().persist(new ItemAdded(cartId, cmd.itemId(), cmd.quantity()))
+          .thenRun(updatedCart -> cmd.replyTo().tell(StatusReply.success(updatedCart.toSummary())));
       }
     }
 
     Effect<Event, State> onRemoveItem(State state, RemoveItem cmd) {
-      if (state.hasItem(cmd.itemId)) {
-        return Effect().persist(new ItemRemoved(cartId, cmd.itemId))
-          .thenRun(updatedCart -> cmd.replyTo.tell(StatusReply.success(updatedCart.toSummary())));
+      if (state.hasItem(cmd.itemId())) {
+        return Effect().persist(new ItemRemoved(cartId, cmd.itemId()))
+          .thenRun(updatedCart -> cmd.replyTo().tell(StatusReply.success(updatedCart.toSummary())));
       } else {
-        cmd.replyTo.tell(StatusReply.success(state.toSummary()));
+        cmd.replyTo().tell(StatusReply.success(state.toSummary()));
         return Effect().none();
       }
     }
 
     Effect<Event, State> onAdjustItemQuantity(State state, AdjustItemQuantity cmd) {
-      if (cmd.quantity <= 0) {
-        cmd.replyTo.tell(StatusReply.error("Quantity must be greater than zero"));
+      if (cmd.quantity() <= 0) {
+        cmd.replyTo().tell(StatusReply.error("Quantity must be greater than zero"));
         return Effect().none();
-      } else if (state.hasItem(cmd.itemId)) {
-        return Effect().persist(new ItemQuantityAdjusted(cartId, cmd.itemId, cmd.quantity))
-          .thenRun(updatedCart -> cmd.replyTo.tell(StatusReply.success(updatedCart.toSummary())));
+      } else if (state.hasItem(cmd.itemId())) {
+        return Effect().persist(new ItemQuantityAdjusted(cartId, cmd.itemId(), cmd.quantity()))
+          .thenRun(updatedCart -> cmd.replyTo().tell(StatusReply.success(updatedCart.toSummary())));
       } else {
-        cmd.replyTo.tell(StatusReply.error(
-          "Cannot adjust quantity for item '" + cmd.itemId + "'. Item not present on cart"));
+        cmd.replyTo().tell(StatusReply.error(
+          "Cannot adjust quantity for item '" + cmd.itemId() + "'. Item not present on cart"));
         return Effect().none();
       }
     }
 
     Effect<Event, State> onCheckout(State state, Checkout cmd) {
       if (state.isEmpty()) {
-        cmd.replyTo.tell(StatusReply.error("Cannot checkout an empty shopping cart"));
+        cmd.replyTo().tell(StatusReply.error("Cannot checkout an empty shopping cart"));
         return Effect().none();
       } else {
         return Effect().persist(new CheckedOut(cartId, Instant.now()))
-          .thenRun(updatedCart -> cmd.replyTo.tell(StatusReply.success(updatedCart.toSummary())));
+          .thenRun(updatedCart -> cmd.replyTo().tell(StatusReply.success(updatedCart.toSummary())));
       }
     }
   }
 
   private class CheckedOutCommandHandlers {
     Effect<Event, State> onAddItem(AddItem cmd) {
-      cmd.replyTo.tell(StatusReply.error("Can't add an item to an already checked out shopping cart"));
+      cmd.replyTo().tell(StatusReply.error("Can't add an item to an already checked out shopping cart"));
       return Effect().none();
     }
 
     Effect<Event, State> onRemoveItem(RemoveItem cmd) {
-      cmd.replyTo.tell(StatusReply.error("Can't remove an item from an already checked out shopping cart"));
+      cmd.replyTo().tell(StatusReply.error("Can't remove an item from an already checked out shopping cart"));
       return Effect().none();
     }
 
     Effect<Event, State> onAdjustItemQuantity(AdjustItemQuantity cmd) {
-      cmd.replyTo.tell(StatusReply.error("Can't adjust item on an already checked out shopping cart"));
+      cmd.replyTo().tell(StatusReply.error("Can't adjust item on an already checked out shopping cart"));
       return Effect().none();
     }
 
     Effect<Event, State> onCheckout(Checkout cmd) {
-      cmd.replyTo.tell(StatusReply.error("Can't checkout already checked out shopping cart"));
+      cmd.replyTo().tell(StatusReply.error("Can't checkout already checked out shopping cart"));
       return Effect().none();
     }
   }
@@ -374,10 +290,10 @@ public class ShoppingCart
   @Override
   public EventHandler<State, Event> eventHandler() {
     return newEventHandlerBuilder().forAnyState()
-      .onEvent(ItemAdded.class, (state, event) -> state.updateItem(event.itemId, event.quantity))
-      .onEvent(ItemRemoved.class, (state, event) -> state.removeItem(event.itemId))
-      .onEvent(ItemQuantityAdjusted.class, (state, event) -> state.updateItem(event.itemId, event.quantity))
-      .onEvent(CheckedOut.class, (state, event) -> state.checkout(event.eventTime))
+      .onEvent(ItemAdded.class, (state, event) -> state.updateItem(event.itemId(), event.quantity()))
+      .onEvent(ItemRemoved.class, (state, event) -> state.removeItem(event.itemId()))
+      .onEvent(ItemQuantityAdjusted.class, (state, event) -> state.updateItem(event.itemId(), event.quantity()))
+      .onEvent(CheckedOut.class, (state, event) -> state.checkout(event.eventTime()))
       .build();
   }
 


### PR DESCRIPTION
### Motivation
Java 17 introduced records, pattern matching for instanceof, and other features that make Java code more concise and readable. The example code contained many verbose data carrier classes and instanceof + explicit cast patterns that can be significantly simplified.

### Modification
- Convert data carrier classes (commands, events, messages) to Java records across sample applications
- Use pattern matching for instanceof to eliminate explicit casts
- Update all field accesses from direct field access to record accessor methods
- Remove redundant equals/hashCode/constructor boilerplate

Files changed:
- `pekko-sample-persistence-java/`: ShoppingCart
- `pekko-sample-distributed-data-java/`: ShoppingCart, VotingService, ReplicatedCache
- `pekko-sample-cluster-client-grpc-java/`: ClusterClient
- `pekko-sample-persistence-dc-java/`: ThumbsUpCounter

### Result
Example Java code is more concise and idiomatic for Java 17+, reducing boilerplate while maintaining the same behavior. Net reduction of ~350 lines of code across 6 files.

### Tests
Not run - sample applications without automated test suite

### References
None - code modernization