### PR TITLE
fix: replace deprecated bindAndHandle with newServerAt().bind() in Java samples

### DIFF
--- a/pekko-sample-cluster-kubernetes-java/src/main/java/pekko/cluster/bootstrap/demo/DemoApp.java
+++ b/pekko-sample-cluster-kubernetes-java/src/main/java/pekko/cluster/bootstrap/demo/DemoApp.java
@@ -11,11 +11,9 @@ import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import org.apache.pekko.cluster.ClusterEvent;
 import org.apache.pekko.cluster.typed.Cluster;
 import org.apache.pekko.cluster.typed.Subscribe;
-import org.apache.pekko.http.javadsl.ConnectHttp;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.management.cluster.bootstrap.ClusterBootstrap;
 import org.apache.pekko.management.scaladsl.PekkoManagement;
-import org.apache.pekko.stream.Materializer;
 
 import static org.apache.pekko.http.javadsl.server.Directives.*;
 
@@ -44,10 +42,8 @@ public class DemoApp {
     public static Behavior<Void> create() {
       return Behaviors.setup(context -> {
         final org.apache.pekko.actor.ActorSystem classicSystem = Adapter.toClassic(context.getSystem());
-        Materializer mat = Materializer.matFromSystem(classicSystem);
 
-        Http.get(classicSystem).bindAndHandle(complete("Hello world")
-                .flow(classicSystem, mat), ConnectHttp.toHost("0.0.0.0", 8080), mat)
+        Http.get(classicSystem).newServerAt("0.0.0.0", 8080).bind(complete("Hello world"))
                 .whenComplete((binding, failure) -> {
                   if (failure == null) {
                     classicSystem.log().info("HTTP server now listening at port 8080");

--- a/pekko-sample-sharding-java/killrweather/src/main/java/sample/killrweather/WeatherHttpServer.java
+++ b/pekko-sample-sharding-java/killrweather/src/main/java/sample/killrweather/WeatherHttpServer.java
@@ -3,11 +3,8 @@ package sample.killrweather;
 import org.apache.pekko.actor.CoordinatedShutdown;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.actor.typed.javadsl.Adapter;
-import org.apache.pekko.http.javadsl.ConnectHttp;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.server.Route;
-import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.SystemMaterializer;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -19,13 +16,8 @@ final class WeatherHttpServer {
   public static void start(Route routes, int port, ActorSystem<?> system) {
     org.apache.pekko.actor.ActorSystem classicActorSystem = Adapter.toClassic(system);
 
-    Materializer materializer = SystemMaterializer.get(system).materializer();
-
-    Http.get(classicActorSystem).bindAndHandle(
-        routes.flow(classicActorSystem, materializer),
-        ConnectHttp.toHost("localhost", port),
-        materializer
-    ).whenComplete((binding, failure) -> {
+    Http.get(classicActorSystem).newServerAt("localhost", port).bind(routes)
+    .whenComplete((binding, failure) -> {
       if (failure == null) {
         final InetSocketAddress address = binding.localAddress();
         system.log().info(


### PR DESCRIPTION
### Motivation
Two Java sample files use the deprecated `Http.bindAndHandle()` API, producing deprecation warnings during compilation.

### Modification
- **WeatherHttpServer.java** (pekko-sample-sharding-java): replace `bindAndHandle` with `newServerAt("localhost", port).bind(routes)`, remove unused `ConnectHttp`, `Materializer` and `SystemMaterializer` imports
- **DemoApp.java** (pekko-sample-cluster-kubernetes-java): replace `bindAndHandle` with `newServerAt("0.0.0.0", 8080).bind(complete(...))`, remove unused `ConnectHttp` and `Materializer` imports

### Result
Samples use the modern HTTP server binding API. No more deprecation warnings from these files.

### Tests
- `sbt compile` in pekko-sample-sharding-java - no warnings
- pekko-sample-cluster-kubernetes-java: Not run - pre-existing dependency resolution issue (Maven project with missing published artifacts)

### References
None - cleanup